### PR TITLE
big PR to enhance docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# don't copy these files into docker image
+.git
+Dockerfile
+README.md
+docker-compose*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,45 @@
-FROM debian:stable-slim
+FROM debian:stable-slim as build
 
 # Configure base image
 RUN apt-get update && apt-get install -y \
   wget \
-  xz-utils
-
-# Setup CLI exports
-RUN export SFDX_AUTOUPDATE_DISABLE=false \
-  # export SFDX_USE_GENERIC_UNIX_KEYCHAIN=true \
-  export SFDX_DOMAIN_RETRY=300 \
-  export SFDX_DISABLE_APP_HUB=true \
-  export SFDX_LOG_LEVEL=DEBUG
+  xz-utils \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Salesforce CLI binary
-RUN mkdir sfdx
-RUN wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1
-RUN "./sfdx/install"
-RUN export PATH=./sfdx/$(pwd):$PATH
+WORKDIR /
+RUN mkdir /sfdx \
+    && wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJ -C sfdx --strip-components 1 \
+    && /sfdx/install \
+    && rm -rf /sfdx
+
+### LAST STAGE
+FROM debian:stable-slim as run
+###
+
+# Setup CLI exports
+ENV SFDX_AUTOUPDATE_DISABLE=false \
+  # export SFDX_USE_GENERIC_UNIX_KEYCHAIN=true \
+  SFDX_DOMAIN_RETRY=300 \
+  SFDX_DISABLE_APP_HUB=true \
+  SFDX_LOG_LEVEL=DEBUG \
+  TERM=xterm-256color
+
+COPY --from=build /usr/local/lib/sfdx /usr/local/lib/sfdx
+RUN ln -sf /usr/local/lib/sfdx/bin/sfdx /usr/local/bin/sfdx
 RUN sfdx update
 
 # Check version of Salesforce CLI
-RUN sfdx --version
-RUN sfdx plugins --core
+# RUN sfdx --version && sfdx plugins --core
 
-# Set the working directory to /app
-WORKDIR /app
-
-# Copy the current directory contents into the container at /app
-ADD . /app
+# copy in entrypoint
+COPY docker-entrypoint.sh .
 
 # Make the scripts executeable
-RUN ["chmod", "+x", "/app/auth.sh"]
+RUN chmod +x docker-entrypoint.sh
 
-# Run the script
-# CMD ["bash", "auth.sh"]
-ENTRYPOINT ["/app/auth.sh"]
+# Run the entrypoint script on startup
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
+# default CMD, should be run in shell so we'll skip the JSON syntax
+CMD sfdx help

--- a/auth.sh
+++ b/auth.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-echo "$SFDX_DEV_HUB_AUTH_URL" > sfdxurl
-sfdx force:auth:sfdxurl:store -f sfdxurl -d -a DevHub
-
-# prevent script from exiting
-echo "Prevent script from exiting"
-tail -f /dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+services:
+  sfdx:
+    image: bretfisher/sfdx
+    build: .
+    volumes:
+      - ~/.sfdx:/root/.sfdx
+    environment:
+      SFDX_DEV_HUB_AUTH_URL: "${SFDX_DEV_HUB_AUTH_URL}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# give them choice, if /root/.sfdx exists, use it, if not, expect envvar
+if [ -f /root/.sfdx/sfdx-config.json ]; then
+  echo "I see .sfdx, so I'll use auth files there"
+else
+  if [ -n $SFDX_DEV_HUB_AUTH_URL ]; then
+    echo "using SFDX_DEV_HUB_AUTH_URL for auth"
+    echo "$SFDX_DEV_HUB_AUTH_URL" > sfdxurl
+    sfdx force:auth:sfdxurl:store -f sfdxurl -d -a DevHub
+  else
+    env
+    echo "no .sfdx or ENV SFDX_DEV_HUB_AUTH_URL exists, exiting" 
+    exit 1
+  fi
+fi
+
+
+


### PR DESCRIPTION
Sorry for a single big PR

- use multi-stage build to save 13MB on final image size
- change auth.sh to entrypoint script
- enhance entrypoint to look for either bind-mount of .sfdx, then envvar, then fail if neither exists
- add compose file for `docker-compose run sfdx` option
